### PR TITLE
Data persistence with EEPROM Emulation

### DIFF
--- a/Core/Inc/data_persist.h
+++ b/Core/Inc/data_persist.h
@@ -9,7 +9,7 @@
  * @return int
  */
 int
-eeprom_store_key(totp_service* service);
+eeprom_store_service(totp_service* service);
 
 /**
  * @brief Read service struct data from emulated EEPROM.
@@ -18,7 +18,7 @@ eeprom_store_key(totp_service* service);
  * @return int
  */
 int
-eeprom_read_key(totp_service* service_restored);
+eeprom_read_service(totp_service* service_restored);
 
 int
 eeprom_data_init();

--- a/Core/Inc/data_persist.h
+++ b/Core/Inc/data_persist.h
@@ -1,0 +1,14 @@
+#include "main.h"
+#include <stdio.h>
+
+int
+eeprom_store_key(totp_service* service);
+
+int
+eeprom_read_key(totp_service* service);
+
+int
+eeprom_data_init();
+
+int
+eeprom_test();

--- a/Core/Inc/data_persist.h
+++ b/Core/Inc/data_persist.h
@@ -1,11 +1,24 @@
 #include "main.h"
 #include <stdio.h>
 
+
+/**
+ * @brief Store service struct data to emulated EEPROM
+ * 
+ * @param service 
+ * @return int 
+ */
 int
 eeprom_store_key(totp_service* service);
 
+/**
+ * @brief Read service struct data from emulated EEPROM. 
+ * 
+ * @param service_restored 
+ * @return int 
+ */
 int
-eeprom_read_key(totp_service* service);
+eeprom_read_key(totp_service* service_restored);
 
 int
 eeprom_data_init();

--- a/Core/Inc/data_persist.h
+++ b/Core/Inc/data_persist.h
@@ -1,21 +1,21 @@
+#include "eeprom.h"
 #include "main.h"
 #include <stdio.h>
 
-
 /**
  * @brief Store service struct data to emulated EEPROM
- * 
- * @param service 
- * @return int 
+ *
+ * @param service
+ * @return int
  */
 int
 eeprom_store_key(totp_service* service);
 
 /**
- * @brief Read service struct data from emulated EEPROM. 
- * 
- * @param service_restored 
- * @return int 
+ * @brief Read service struct data from emulated EEPROM.
+ *
+ * @param service_restored
+ * @return int
  */
 int
 eeprom_read_key(totp_service* service_restored);

--- a/Core/Inc/data_persist.h
+++ b/Core/Inc/data_persist.h
@@ -18,10 +18,16 @@ eeprom_store_service(totp_service* service);
  * @return int
  */
 int
-eeprom_read_service(totp_service* service_restored);
+eeprom_read_service(totp_service* service_restored, int id);
 
 int
 eeprom_data_init();
+
+uint16_t
+eeprom_stat();
+
+void
+eeprom_update_index();
 
 int
 eeprom_test();

--- a/Core/Inc/eeprom.h
+++ b/Core/Inc/eeprom.h
@@ -1,0 +1,84 @@
+/**
+  ******************************************************************************
+  * @file    EEPROM/EEPROM_Emulation/inc/eeprom.h 
+  * @author  MCD Application Team
+  * @brief   This file contains all the functions prototypes for the EEPROM 
+  *          emulation firmware library.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __EEPROM_H
+#define __EEPROM_H
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx_hal.h"
+
+/* Exported constants --------------------------------------------------------*/
+/* EEPROM emulation firmware error codes */
+#define EE_OK      (uint32_t)HAL_OK
+#define EE_ERROR   (uint32_t)HAL_ERROR
+#define EE_BUSY    (uint32_t)HAL_BUSY
+#define EE_TIMEOUT (uint32_t)HAL_TIMEOUT
+
+/* Define the size of the sectors to be used */
+#define PAGE_SIZE               (uint32_t)0x4000  /* Page size = 16KByte */
+
+/* Device voltage range supposed to be [2.7V to 3.6V], the operation will 
+   be done by word  */
+#define VOLTAGE_RANGE           (uint8_t)VOLTAGE_RANGE_3
+
+/* EEPROM start address in Flash */
+#define EEPROM_START_ADDRESS  ((uint32_t)0x08008000) /* EEPROM emulation start address:
+                                                  from sector2 : after 16KByte of used 
+                                                  Flash memory */
+
+/* Pages 0 and 1 base and end addresses */
+#define PAGE0_BASE_ADDRESS    ((uint32_t)(EEPROM_START_ADDRESS + 0x0000))
+#define PAGE0_END_ADDRESS     ((uint32_t)(EEPROM_START_ADDRESS + (PAGE_SIZE - 1)))
+#define PAGE0_ID               FLASH_SECTOR_2
+
+#define PAGE1_BASE_ADDRESS    ((uint32_t)(EEPROM_START_ADDRESS + 0x4000))
+#define PAGE1_END_ADDRESS     ((uint32_t)(EEPROM_START_ADDRESS + (2 * PAGE_SIZE - 1)))
+#define PAGE1_ID               FLASH_SECTOR_3
+
+/* Used Flash pages for EEPROM emulation */
+#define PAGE0                 ((uint16_t)0x0000)
+#define PAGE1                 ((uint16_t)0x0001) /* Page nb between PAGE0_BASE_ADDRESS & PAGE1_BASE_ADDRESS*/
+
+/* No valid page define */
+#define NO_VALID_PAGE         ((uint16_t)0x00AB)
+
+/* Page status definitions */
+#define ERASED                ((uint16_t)0xFFFF)     /* Page is empty */
+#define RECEIVE_DATA          ((uint16_t)0xEEEE)     /* Page is marked to receive data */
+#define VALID_PAGE            ((uint16_t)0x0000)     /* Page containing valid data */
+
+/* Valid pages in read and write defines */
+#define READ_FROM_VALID_PAGE  ((uint8_t)0x00)
+#define WRITE_IN_VALID_PAGE   ((uint8_t)0x01)
+
+/* Page full define */
+#define PAGE_FULL             ((uint8_t)0x80)
+
+/* Variables' number */
+#define NB_OF_VAR             ((uint8_t)0x03)
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions ------------------------------------------------------- */
+uint16_t EE_Init(void);
+uint16_t EE_ReadVariable(uint16_t VirtAddress, uint16_t* Data);
+uint16_t EE_WriteVariable(uint16_t VirtAddress, uint16_t Data);
+
+#endif /* __EEPROM_H */

--- a/Core/Inc/eeprom.h
+++ b/Core/Inc/eeprom.h
@@ -71,8 +71,9 @@
 /* Page full define */
 #define PAGE_FULL             ((uint8_t)0x80)
 
+#define MAX_SERVICES          ((uint8_t)32)
 /* Variables' number */
-#define NB_OF_VAR             ((uint8_t)0x03)
+#define NB_OF_VAR             ((uint8_t)MAX_SERVICES + 1)
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported macro ------------------------------------------------------------*/

--- a/Core/Inc/eeprom.h
+++ b/Core/Inc/eeprom.h
@@ -74,7 +74,7 @@
 
 /* Variables' number */
 /* Proabably a bad idea to mix driver/application layers... */
-#define NB_OF_VAR             MAX_SERVICES
+#define NB_OF_VAR             (MAX_SERVICES + 1)
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported macro ------------------------------------------------------------*/

--- a/Core/Inc/eeprom.h
+++ b/Core/Inc/eeprom.h
@@ -23,6 +23,7 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f4xx_hal.h"
+#include "user_utils.h"
 
 /* Exported constants --------------------------------------------------------*/
 /* EEPROM emulation firmware error codes */
@@ -71,9 +72,9 @@
 /* Page full define */
 #define PAGE_FULL             ((uint8_t)0x80)
 
-#define MAX_SERVICES          ((uint8_t)32)
 /* Variables' number */
-#define NB_OF_VAR             ((uint8_t)MAX_SERVICES + 1)
+/* Proabably a bad idea to mix driver/application layers... */
+#define NB_OF_VAR             MAX_SERVICES
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported macro ------------------------------------------------------------*/

--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -37,6 +37,7 @@ extern "C"
 #include "st7735s_compat.h"
 #include "time_rtc.h"
 #include "user_utils.h"
+#include "eeprom.h"
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>

--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -37,7 +37,6 @@ extern "C"
 #include "st7735s_compat.h"
 #include "time_rtc.h"
 #include "user_utils.h"
-#include "eeprom.h"
 #include "data_persist.h"
 #include <stdbool.h>
 #include <stdio.h>

--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -38,6 +38,7 @@ extern "C"
 #include "time_rtc.h"
 #include "user_utils.h"
 #include "eeprom.h"
+#include "data_persist.h"
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>

--- a/Core/Inc/user_utils.h
+++ b/Core/Inc/user_utils.h
@@ -17,6 +17,7 @@
 #define util_usart_printf printf
 
 #define SERVICE_DISP_LEN 24
+#define MAX_SERVICES 32
 
 typedef enum AT_RES_ENUM
 {
@@ -66,6 +67,8 @@ void
 util_parse_conf(char* raw, int str_len);
 void
 util_parse_segment(char* raw, int start, int end);
+totp_service*
+util_save_service(int id, char* name, char* key, int name_len, int key_len);
 int
 util_totp_from_service(totp_service* service);
 #endif

--- a/Core/Inc/user_utils.h
+++ b/Core/Inc/user_utils.h
@@ -13,6 +13,7 @@
 #include "gfx.h"
 #include "st7735s.h"
 
+/* Data must be flushed with LF(\n) to be actually printed to stdout(serial)! */
 #define util_usart_printf printf
 
 #define SERVICE_DISP_LEN 24
@@ -26,8 +27,8 @@ typedef enum AT_RES_ENUM
 
 typedef struct totp_service_t
 {
-  char name[128];
-  char key[64];
+  char name[16];
+  char key[16];
 } totp_service;
 
 extern UART_HandleTypeDef huart3;

--- a/Core/Inc/user_utils.h
+++ b/Core/Inc/user_utils.h
@@ -25,6 +25,10 @@ typedef enum AT_RES_ENUM
   AT_READY = 2,
 } AT_RES;
 
+/**
+ * @brief TOTP Service definition
+ * Name and key (secret) are both 16-byte.
+ */
 typedef struct totp_service_t
 {
   char name[16];

--- a/Core/Src/data_persist.c
+++ b/Core/Src/data_persist.c
@@ -1,0 +1,161 @@
+#include "data_persist.h"
+#include "eeprom.h"
+
+#define VIRT_ADDR_OFFSET 0x5000
+#define INDEX_VAR_VIRT_ADDR 0xfff0
+
+#define upper_16(x) ((x & 0xff00) >> 8)
+#define lower_16(x) (x & 0x00ff)
+#define merge_8_to_16(upper, lower) ((upper << 8) + lower)
+
+/* Virtual address defined by the user: 0xFFFF value is prohibited */
+/* Note:
+ * 1. Virtual address is actually a "tag" to identify data segments.
+ * 2. Virtual addresses must be pre-allocated before all write/read operations,
+ * since in the power failure recovery process (in EE_Init) the virtual
+ * addresses defined in VirtAddVarTab will be used to identify saved data
+ * segments in flash.
+ */
+uint16_t VirtAddVarTab[NB_OF_VAR] = {};
+uint16_t VarDataTab[NB_OF_VAR] = {};
+uint16_t VarValue, VarDataTmp = 0;
+
+uint16_t test_addr = 0xfff0;
+uint16_t test_value = 0x0102;
+uint16_t test_tmp = 0U;
+
+int service_stored = 0; // Number of services stored in EEPROM
+
+int
+eeprom_store_key(totp_service* service)
+{
+  HAL_FLASH_Unlock();
+  /* EEPROM Init */
+  if (EE_Init() != EE_OK) {
+    Error_Handler();
+  }
+
+  /* Current service name/key size limit is 16 bytes / 8 halfwords */
+  HAL_StatusTypeDef res = HAL_OK;
+
+  printf("Storing service: %s, %s\n", service->name, service->key);
+  for (int i = 0; i < 8; i++) {
+    if (EE_WriteVariable(VIRT_ADDR_OFFSET + service_stored * 16 + i,
+                         merge_8_to_16(service->name[i * 2 + 0],
+                                       service->name[i * 2 + 1])) != HAL_OK ||
+        EE_WriteVariable(VIRT_ADDR_OFFSET + service_stored * 16 + 8 + i,
+                         merge_8_to_16(service->key[i * 2 + 0],
+                                       service->key[i * 2 + 1])) != HAL_OK) {
+      printf("Store key error! \n");
+      for (;;)
+        ;
+    }
+
+    printf("Written to 0x%x and 0x%x\n",
+           VIRT_ADDR_OFFSET + service_stored * 16 + i,
+           VIRT_ADDR_OFFSET + service_stored * 16 + 8 + i);
+  }
+  service_stored++;
+
+  HAL_FLASH_Lock();
+}
+
+int
+eeprom_read_key(totp_service* service)
+{
+  HAL_FLASH_Unlock();
+  /* EEPROM Init */
+  if (EE_Init() != EE_OK) {
+    Error_Handler();
+  }
+
+  uint16_t name_tmp = 0;
+  uint16_t key_tmp = 0;
+  char upper = 0, lower = 0;
+
+  HAL_StatusTypeDef res = HAL_OK;
+  for (int idx = 0; idx < service_stored; idx++) {
+    for (int i = 0; i < 8; i++) {
+      if (EE_ReadVariable(VIRT_ADDR_OFFSET + idx * 16 + i, &name_tmp) !=
+            HAL_OK ||
+          EE_ReadVariable(VIRT_ADDR_OFFSET + idx * 16 + 8 + i, &key_tmp) !=
+            HAL_OK) {
+        printf("Read key error! \n");
+      }
+      printf("Read from 0x%x and 0x%x\n",
+             VIRT_ADDR_OFFSET + idx * 16 + i,
+             VIRT_ADDR_OFFSET + idx * 16 + 8 + i);
+
+      service->name[i * 2] = upper_16(name_tmp);
+      service->name[i * 2 + 1] = lower_16(name_tmp);
+      service->key[i * 2] = upper_16(key_tmp);
+      service->key[i * 2 + 1] = lower_16(key_tmp);
+    }
+    printf("Recovered service: %s, %s\n", service->name, service->key);
+  }
+
+  HAL_FLASH_Lock();
+}
+
+int
+eeprom_data_init()
+{
+  uint16_t alloc_addr = 0x00;
+  for (int i = 0; i < NB_OF_VAR - 1; i++) {
+    VirtAddVarTab[i] = alloc_addr;
+    alloc_addr += 0x0010;
+  }
+  /* Finally, format the index variable */
+  VirtAddVarTab[NB_OF_VAR - 1] = INDEX_VAR_VIRT_ADDR;
+
+  for (int i = 0; i < NB_OF_VAR; i++) {
+    printf("Allocated Virt Addr: ");
+    printf("0x%x, ", VirtAddVarTab[i]);
+    printf("\n");
+  }
+
+  HAL_FLASH_Unlock();
+
+  /* EEPROM Init */
+  if (EE_Init() != EE_OK) {
+    Error_Handler();
+  }
+
+  HAL_FLASH_Lock();
+}
+
+int
+eeprom_test()
+{
+  HAL_FLASH_Unlock();
+  /* EEPROM Init */
+  if (EE_Init() != EE_OK) {
+    Error_Handler();
+  }
+
+  /* --- Store successively many values of the three variables in the EEPROM
+   * ---*/
+  /* Store 0x1000 values of Variable1 in EEPROM */
+  //   if ((EE_ReadVariable(test_addr, test_tmp)) != HAL_OK) {
+  //     Error_Handler();
+  //   }
+
+  if ((EE_ReadVariable(test_addr, &test_tmp)) != HAL_OK) {
+    printf("Didn't find valid data at virtual EEPROM address 0x%x\n",
+           test_addr);
+  } else {
+    printf("0xffff = 0x%x, Expected 0x%x\n", test_tmp, test_value);
+  }
+
+  if ((EE_WriteVariable(test_addr, test_value)) != HAL_OK) {
+    printf("Write failed! \n");
+  }
+
+  if ((EE_ReadVariable(test_addr, &test_tmp)) != HAL_OK) {
+    printf("Failed to read 0x%x\n", test_addr);
+  } else {
+    printf("0xffff = 0x%x, Expected 0x%x\n", test_tmp, test_value);
+  }
+
+  HAL_FLASH_Lock();
+}

--- a/Core/Src/data_persist.c
+++ b/Core/Src/data_persist.c
@@ -26,7 +26,7 @@ uint16_t test_tmp = 0U;
 int service_stored = 0; // Number of services stored in EEPROM
 
 int
-eeprom_store_key(totp_service* service)
+eeprom_store_service(totp_service* service)
 {
   HAL_FLASH_Unlock();
   /* EEPROM Init */
@@ -60,7 +60,7 @@ eeprom_store_key(totp_service* service)
 }
 
 int
-eeprom_read_key(totp_service* service_restored)
+eeprom_read_service(totp_service* service_restored)
 {
   HAL_FLASH_Unlock();
   /* EEPROM Init */

--- a/Core/Src/data_persist.c
+++ b/Core/Src/data_persist.c
@@ -61,7 +61,7 @@ eeprom_store_key(totp_service* service)
 }
 
 int
-eeprom_read_key(totp_service* service)
+eeprom_read_key(totp_service* service_restored)
 {
   HAL_FLASH_Unlock();
   /* EEPROM Init */
@@ -86,12 +86,14 @@ eeprom_read_key(totp_service* service)
              VIRT_ADDR_OFFSET + idx * 16 + i,
              VIRT_ADDR_OFFSET + idx * 16 + 8 + i);
 
-      service->name[i * 2] = upper_16(name_tmp);
-      service->name[i * 2 + 1] = lower_16(name_tmp);
-      service->key[i * 2] = upper_16(key_tmp);
-      service->key[i * 2 + 1] = lower_16(key_tmp);
+      service_restored->name[i * 2] = upper_16(name_tmp);
+      service_restored->name[i * 2 + 1] = lower_16(name_tmp);
+      service_restored->key[i * 2] = upper_16(key_tmp);
+      service_restored->key[i * 2 + 1] = lower_16(key_tmp);
     }
-    printf("Recovered service: %s, %s\n", service->name, service->key);
+    printf("Recovered service: %s, %s\n",
+           service_restored->name,
+           service_restored->key);
   }
 
   HAL_FLASH_Lock();
@@ -132,13 +134,6 @@ eeprom_test()
   if (EE_Init() != EE_OK) {
     Error_Handler();
   }
-
-  /* --- Store successively many values of the three variables in the EEPROM
-   * ---*/
-  /* Store 0x1000 values of Variable1 in EEPROM */
-  //   if ((EE_ReadVariable(test_addr, test_tmp)) != HAL_OK) {
-  //     Error_Handler();
-  //   }
 
   if ((EE_ReadVariable(test_addr, &test_tmp)) != HAL_OK) {
     printf("Didn't find valid data at virtual EEPROM address 0x%x\n",

--- a/Core/Src/data_persist.c
+++ b/Core/Src/data_persist.c
@@ -1,5 +1,4 @@
 #include "data_persist.h"
-#include "eeprom.h"
 
 #define VIRT_ADDR_OFFSET 0x5000
 #define INDEX_VAR_VIRT_ADDR 0xfff0

--- a/Core/Src/eeprom.c
+++ b/Core/Src/eeprom.c
@@ -1,0 +1,708 @@
+/**
+  ******************************************************************************
+  * @file    EEPROM/EEPROM_Emulation/src/eeprom.c 
+  * @author  MCD Application Team
+  * @brief   This file provides all the EEPROM emulation firmware functions.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+/** @addtogroup EEPROM_Emulation
+  * @{
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "eeprom.h"
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+
+/* Global variable used to store variable value in read sequence */
+uint16_t DataVar = 0;
+
+/* Virtual address defined by the user: 0xFFFF value is prohibited */
+extern uint16_t VirtAddVarTab[NB_OF_VAR];
+
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+static HAL_StatusTypeDef EE_Format(void);
+static uint16_t EE_FindValidPage(uint8_t Operation);
+static uint16_t EE_VerifyPageFullWriteVariable(uint16_t VirtAddress, uint16_t Data);
+static uint16_t EE_PageTransfer(uint16_t VirtAddress, uint16_t Data);
+static uint16_t EE_VerifyPageFullyErased(uint32_t Address);
+
+/**
+  * @brief  Restore the pages to a known good state in case of page's status
+  *   corruption after a power loss.
+  * @param  None.
+  * @retval - Flash error code: on write Flash error
+  *         - FLASH_COMPLETE: on success
+  */
+uint16_t EE_Init(void)
+{
+  uint16_t PageStatus0 = 6, PageStatus1 = 6;
+  uint16_t VarIdx = 0;
+  uint16_t EepromStatus = 0, ReadStatus = 0;
+  int16_t x = -1;
+  HAL_StatusTypeDef  FlashStatus;
+  uint32_t SectorError = 0;
+  FLASH_EraseInitTypeDef pEraseInit;
+
+
+  /* Get Page0 status */
+  PageStatus0 = (*(__IO uint16_t*)PAGE0_BASE_ADDRESS);
+  /* Get Page1 status */
+  PageStatus1 = (*(__IO uint16_t*)PAGE1_BASE_ADDRESS);
+
+  pEraseInit.TypeErase = TYPEERASE_SECTORS;
+  pEraseInit.Sector = PAGE0_ID;
+  pEraseInit.NbSectors = 1;
+  pEraseInit.VoltageRange = VOLTAGE_RANGE;
+  
+  /* Check for invalid header states and repair if necessary */
+  switch (PageStatus0)
+  {
+    case ERASED:
+      if (PageStatus1 == VALID_PAGE) /* Page0 erased, Page1 valid */
+      {
+          /* Erase Page0 */
+        if(!EE_VerifyPageFullyErased(PAGE0_BASE_ADDRESS))
+        {
+          FlashStatus = HAL_FLASHEx_Erase(&pEraseInit, &SectorError);
+          /* If erase operation was failed, a Flash error code is returned */
+          if (FlashStatus != HAL_OK)
+          {
+            return FlashStatus;
+          }
+        }
+      }
+      else if (PageStatus1 == RECEIVE_DATA) /* Page0 erased, Page1 receive */
+      {
+        /* Erase Page0 */
+        if(!EE_VerifyPageFullyErased(PAGE0_BASE_ADDRESS))
+        { 
+          FlashStatus = HAL_FLASHEx_Erase(&pEraseInit, &SectorError);
+          /* If erase operation was failed, a Flash error code is returned */
+          if (FlashStatus != HAL_OK)
+          {
+            return FlashStatus;
+          }
+        }
+        /* Mark Page1 as valid */
+        FlashStatus = HAL_FLASH_Program(TYPEPROGRAM_HALFWORD, PAGE1_BASE_ADDRESS, VALID_PAGE);
+        /* If program operation was failed, a Flash error code is returned */
+        if (FlashStatus != HAL_OK)
+        {
+          return FlashStatus;
+        }
+      }
+      else /* First EEPROM access (Page0&1 are erased) or invalid state -> format EEPROM */
+      {
+        /* Erase both Page0 and Page1 and set Page0 as valid page */
+        FlashStatus = EE_Format();
+        /* If erase/program operation was failed, a Flash error code is returned */
+        if (FlashStatus != HAL_OK)
+        {
+          return FlashStatus;
+        }
+      }
+      break;
+
+    case RECEIVE_DATA:
+      if (PageStatus1 == VALID_PAGE) /* Page0 receive, Page1 valid */
+      {
+        /* Transfer data from Page1 to Page0 */
+        for (VarIdx = 0; VarIdx < NB_OF_VAR; VarIdx++)
+        {
+          if (( *(__IO uint16_t*)(PAGE0_BASE_ADDRESS + 6)) == VirtAddVarTab[VarIdx])
+          {
+            x = VarIdx;
+          }
+          if (VarIdx != x)
+          {
+            /* Read the last variables' updates */
+            ReadStatus = EE_ReadVariable(VirtAddVarTab[VarIdx], &DataVar);
+            /* In case variable corresponding to the virtual address was found */
+            if (ReadStatus != 0x1)
+            {
+              /* Transfer the variable to the Page0 */
+              EepromStatus = EE_VerifyPageFullWriteVariable(VirtAddVarTab[VarIdx], DataVar);
+              /* If program operation was failed, a Flash error code is returned */
+              if (EepromStatus != HAL_OK)
+              {
+                return EepromStatus;
+              }
+            }
+          }
+        }
+        /* Mark Page0 as valid */
+        FlashStatus = HAL_FLASH_Program(TYPEPROGRAM_HALFWORD, PAGE0_BASE_ADDRESS, VALID_PAGE);
+        /* If program operation was failed, a Flash error code is returned */
+        if (FlashStatus != HAL_OK)
+        {
+          return FlashStatus;
+        }
+        pEraseInit.Sector = PAGE1_ID;
+        pEraseInit.NbSectors = 1;
+        pEraseInit.VoltageRange = VOLTAGE_RANGE;
+        /* Erase Page1 */
+        if(!EE_VerifyPageFullyErased(PAGE1_BASE_ADDRESS))
+        { 
+          FlashStatus = HAL_FLASHEx_Erase(&pEraseInit, &SectorError);
+          /* If erase operation was failed, a Flash error code is returned */
+          if (FlashStatus != HAL_OK)
+          {
+            return FlashStatus;
+          }
+        }
+      }
+      else if (PageStatus1 == ERASED) /* Page0 receive, Page1 erased */
+      {
+        pEraseInit.Sector = PAGE1_ID;
+        pEraseInit.NbSectors = 1;
+        pEraseInit.VoltageRange = VOLTAGE_RANGE;
+        /* Erase Page1 */
+        if(!EE_VerifyPageFullyErased(PAGE1_BASE_ADDRESS))
+        { 
+          FlashStatus = HAL_FLASHEx_Erase(&pEraseInit, &SectorError);
+          /* If erase operation was failed, a Flash error code is returned */
+          if (FlashStatus != HAL_OK)
+          {
+            return FlashStatus;
+          }
+        }
+        /* Mark Page0 as valid */
+        FlashStatus = HAL_FLASH_Program(TYPEPROGRAM_HALFWORD, PAGE0_BASE_ADDRESS, VALID_PAGE);
+        /* If program operation was failed, a Flash error code is returned */
+        if (FlashStatus != HAL_OK)
+        {
+          return FlashStatus;
+        }
+      }
+      else /* Invalid state -> format eeprom */
+      {
+        /* Erase both Page0 and Page1 and set Page0 as valid page */
+        FlashStatus = EE_Format();
+        /* If erase/program operation was failed, a Flash error code is returned */
+        if (FlashStatus != HAL_OK)
+        {
+          return FlashStatus;
+        }
+      }
+      break;
+
+    case VALID_PAGE:
+      if (PageStatus1 == VALID_PAGE) /* Invalid state -> format eeprom */
+      {
+        /* Erase both Page0 and Page1 and set Page0 as valid page */
+        FlashStatus = EE_Format();
+        /* If erase/program operation was failed, a Flash error code is returned */
+        if (FlashStatus != HAL_OK)
+        {
+          return FlashStatus;
+        }
+      }
+      else if (PageStatus1 == ERASED) /* Page0 valid, Page1 erased */
+      {
+        pEraseInit.Sector = PAGE1_ID;
+        pEraseInit.NbSectors = 1;
+        pEraseInit.VoltageRange = VOLTAGE_RANGE;
+        /* Erase Page1 */
+        if(!EE_VerifyPageFullyErased(PAGE1_BASE_ADDRESS))
+        { 
+          FlashStatus = HAL_FLASHEx_Erase(&pEraseInit, &SectorError);
+          /* If erase operation was failed, a Flash error code is returned */
+          if (FlashStatus != HAL_OK)
+          {
+            return FlashStatus;
+          }
+        }
+      }
+      else /* Page0 valid, Page1 receive */
+      {
+        /* Transfer data from Page0 to Page1 */
+        for (VarIdx = 0; VarIdx < NB_OF_VAR; VarIdx++)
+        {
+          if ((*(__IO uint16_t*)(PAGE1_BASE_ADDRESS + 6)) == VirtAddVarTab[VarIdx])
+          {
+            x = VarIdx;
+          }
+          if (VarIdx != x)
+          {
+            /* Read the last variables' updates */
+            ReadStatus = EE_ReadVariable(VirtAddVarTab[VarIdx], &DataVar);
+            /* In case variable corresponding to the virtual address was found */
+            if (ReadStatus != 0x1)
+            {
+              /* Transfer the variable to the Page1 */
+              EepromStatus = EE_VerifyPageFullWriteVariable(VirtAddVarTab[VarIdx], DataVar);
+              /* If program operation was failed, a Flash error code is returned */
+              if (EepromStatus != HAL_OK)
+              {
+                return EepromStatus;
+              }
+            }
+          }
+        }
+        /* Mark Page1 as valid */
+        FlashStatus = HAL_FLASH_Program(TYPEPROGRAM_HALFWORD, PAGE1_BASE_ADDRESS, VALID_PAGE);        
+        /* If program operation was failed, a Flash error code is returned */
+        if (FlashStatus != HAL_OK)
+        {
+          return FlashStatus;
+        }
+        pEraseInit.Sector = PAGE0_ID;
+        pEraseInit.NbSectors = 1;
+        pEraseInit.VoltageRange = VOLTAGE_RANGE;
+        /* Erase Page0 */
+        if(!EE_VerifyPageFullyErased(PAGE0_BASE_ADDRESS))
+        { 
+          FlashStatus = HAL_FLASHEx_Erase(&pEraseInit, &SectorError);
+          /* If erase operation was failed, a Flash error code is returned */
+          if (FlashStatus != HAL_OK)
+          {
+            return FlashStatus;
+          }
+        }
+      }
+      break;
+
+    default:  /* Any other state -> format eeprom */
+      /* Erase both Page0 and Page1 and set Page0 as valid page */
+      FlashStatus = EE_Format();
+      /* If erase/program operation was failed, a Flash error code is returned */
+      if (FlashStatus != HAL_OK)
+      {
+        return FlashStatus;
+      }
+      break;
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Verify if specified page is fully erased.
+  * @param  Address: page address
+  *   This parameter can be one of the following values:
+  *     @arg PAGE0_BASE_ADDRESS: Page0 base address
+  *     @arg PAGE1_BASE_ADDRESS: Page1 base address
+  * @retval page fully erased status:
+  *           - 0: if Page not erased
+  *           - 1: if Page erased
+  */
+uint16_t EE_VerifyPageFullyErased(uint32_t Address)
+{
+  uint32_t ReadStatus = 1;
+  uint16_t AddressValue = 0x5555;
+    
+  /* Check each active page address starting from end */
+  while (Address <= PAGE0_END_ADDRESS)
+  {
+    /* Get the current location content to be compared with virtual address */
+    AddressValue = (*(__IO uint16_t*)Address);
+
+    /* Compare the read address with the virtual address */
+    if (AddressValue != ERASED)
+    {
+      
+      /* In case variable value is read, reset ReadStatus flag */
+      ReadStatus = 0;
+
+      break;
+    }
+    /* Next address location */
+    Address = Address + 4;
+  }
+  
+  /* Return ReadStatus value: (0: Page not erased, 1: Sector erased) */
+  return ReadStatus;
+}
+
+/**
+  * @brief  Returns the last stored variable data, if found, which correspond to
+  *   the passed virtual address
+  * @param  VirtAddress: Variable virtual address
+  * @param  Data: Global variable contains the read variable value
+  * @retval Success or error status:
+  *           - 0: if variable was found
+  *           - 1: if the variable was not found
+  *           - NO_VALID_PAGE: if no valid page was found.
+  */
+uint16_t EE_ReadVariable(uint16_t VirtAddress, uint16_t* Data)
+{
+  uint16_t ValidPage = PAGE0;
+  uint16_t AddressValue = 0x5555, ReadStatus = 1;
+  uint32_t Address = EEPROM_START_ADDRESS, PageStartAddress = EEPROM_START_ADDRESS;
+
+  /* Get active Page for read operation */
+  ValidPage = EE_FindValidPage(READ_FROM_VALID_PAGE);
+
+  /* Check if there is no valid page */
+  if (ValidPage == NO_VALID_PAGE)
+  {
+    return  NO_VALID_PAGE;
+  }
+
+  /* Get the valid Page start Address */
+  PageStartAddress = (uint32_t)(EEPROM_START_ADDRESS + (uint32_t)(ValidPage * PAGE_SIZE));
+
+  /* Get the valid Page end Address */
+  Address = (uint32_t)((EEPROM_START_ADDRESS - 2) + (uint32_t)((1 + ValidPage) * PAGE_SIZE));
+
+  /* Check each active page address starting from end */
+  while (Address > (PageStartAddress + 2))
+  {
+    /* Get the current location content to be compared with virtual address */
+    AddressValue = (*(__IO uint16_t*)Address);
+
+    /* Compare the read address with the virtual address */
+    if (AddressValue == VirtAddress)
+    {
+      /* Get content of Address-2 which is variable value */
+      *Data = (*(__IO uint16_t*)(Address - 2));
+
+      /* In case variable value is read, reset ReadStatus flag */
+      ReadStatus = 0;
+
+      break;
+    }
+    else
+    {
+      /* Next address location */
+      Address = Address - 4;
+    }
+  }
+
+  /* Return ReadStatus value: (0: variable exist, 1: variable doesn't exist) */
+  return ReadStatus;
+}
+
+/**
+  * @brief  Writes/updates variable data in EEPROM.
+  * @param  VirtAddress: Variable virtual address
+  * @param  Data: 16 bit data to be written
+  * @retval Success or error status:
+  *           - FLASH_COMPLETE: on success
+  *           - PAGE_FULL: if valid page is full
+  *           - NO_VALID_PAGE: if no valid page was found
+  *           - Flash error code: on write Flash error
+  */
+uint16_t EE_WriteVariable(uint16_t VirtAddress, uint16_t Data)
+{
+  uint16_t Status = 0;
+
+  /* Write the variable virtual address and value in the EEPROM */
+  Status = EE_VerifyPageFullWriteVariable(VirtAddress, Data);
+
+  /* In case the EEPROM active page is full */
+  if (Status == PAGE_FULL)
+  {
+    /* Perform Page transfer */
+    Status = EE_PageTransfer(VirtAddress, Data);
+  }
+
+  /* Return last operation status */
+  return Status;
+}
+
+/**
+  * @brief  Erases PAGE and PAGE1 and writes VALID_PAGE header to PAGE
+  * @param  None
+  * @retval Status of the last operation (Flash write or erase) done during
+  *         EEPROM formatting
+  */
+static HAL_StatusTypeDef EE_Format(void)
+{
+  HAL_StatusTypeDef FlashStatus = HAL_OK;
+  uint32_t SectorError = 0;
+  FLASH_EraseInitTypeDef pEraseInit;
+
+  pEraseInit.TypeErase = FLASH_TYPEERASE_SECTORS;  
+  pEraseInit.Sector = PAGE0_ID;
+  pEraseInit.NbSectors = 1;
+  pEraseInit.VoltageRange = VOLTAGE_RANGE;
+  /* Erase Page0 */
+  if(!EE_VerifyPageFullyErased(PAGE0_BASE_ADDRESS))
+  {
+    FlashStatus = HAL_FLASHEx_Erase(&pEraseInit, &SectorError); 
+    /* If erase operation was failed, a Flash error code is returned */
+    if (FlashStatus != HAL_OK)
+    {
+      return FlashStatus;
+    }
+  }
+  /* Set Page0 as valid page: Write VALID_PAGE at Page0 base address */
+  FlashStatus = HAL_FLASH_Program(TYPEPROGRAM_HALFWORD, PAGE0_BASE_ADDRESS, VALID_PAGE); 
+  /* If program operation was failed, a Flash error code is returned */
+  if (FlashStatus != HAL_OK)
+  {
+    return FlashStatus;
+  }
+
+  pEraseInit.Sector = PAGE1_ID;
+  /* Erase Page1 */
+  if(!EE_VerifyPageFullyErased(PAGE1_BASE_ADDRESS))
+  {  
+    FlashStatus = HAL_FLASHEx_Erase(&pEraseInit, &SectorError); 
+    /* If erase operation was failed, a Flash error code is returned */
+    if (FlashStatus != HAL_OK)
+    {
+      return FlashStatus;
+    }
+  }
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Find valid Page for write or read operation
+  * @param  Operation: operation to achieve on the valid page.
+  *   This parameter can be one of the following values:
+  *     @arg READ_FROM_VALID_PAGE: read operation from valid page
+  *     @arg WRITE_IN_VALID_PAGE: write operation from valid page
+  * @retval Valid page number (PAGE or PAGE1) or NO_VALID_PAGE in case
+  *   of no valid page was found
+  */
+static uint16_t EE_FindValidPage(uint8_t Operation)
+{
+  uint16_t PageStatus0 = 6, PageStatus1 = 6;
+
+  /* Get Page0 actual status */
+  PageStatus0 = (*(__IO uint16_t*)PAGE0_BASE_ADDRESS);
+
+  /* Get Page1 actual status */
+  PageStatus1 = (*(__IO uint16_t*)PAGE1_BASE_ADDRESS);
+
+  /* Write or read operation */
+  switch (Operation)
+  {
+    case WRITE_IN_VALID_PAGE:   /* ---- Write operation ---- */
+      if (PageStatus1 == VALID_PAGE)
+      {
+        /* Page0 receiving data */
+        if (PageStatus0 == RECEIVE_DATA)
+        {
+          return PAGE0;         /* Page0 valid */
+        }
+        else
+        {
+          return PAGE1;         /* Page1 valid */
+        }
+      }
+      else if (PageStatus0 == VALID_PAGE)
+      {
+        /* Page1 receiving data */
+        if (PageStatus1 == RECEIVE_DATA)
+        {
+          return PAGE1;         /* Page1 valid */
+        }
+        else
+        {
+          return PAGE0;         /* Page0 valid */
+        }
+      }
+      else
+      {
+        return NO_VALID_PAGE;   /* No valid Page */
+      }
+
+    case READ_FROM_VALID_PAGE:  /* ---- Read operation ---- */
+      if (PageStatus0 == VALID_PAGE)
+      {
+        return PAGE0;           /* Page0 valid */
+      }
+      else if (PageStatus1 == VALID_PAGE)
+      {
+        return PAGE1;           /* Page1 valid */
+      }
+      else
+      {
+        return NO_VALID_PAGE ;  /* No valid Page */
+      }
+
+    default:
+      return PAGE0;             /* Page0 valid */
+  }
+}
+
+/**
+  * @brief  Verify if active page is full and Writes variable in EEPROM.
+  * @param  VirtAddress: 16 bit virtual address of the variable
+  * @param  Data: 16 bit data to be written as variable value
+  * @retval Success or error status:
+  *           - FLASH_COMPLETE: on success
+  *           - PAGE_FULL: if valid page is full
+  *           - NO_VALID_PAGE: if no valid page was found
+  *           - Flash error code: on write Flash error
+  */
+static uint16_t EE_VerifyPageFullWriteVariable(uint16_t VirtAddress, uint16_t Data)
+{
+  HAL_StatusTypeDef FlashStatus = HAL_OK;
+  uint16_t ValidPage = PAGE0;
+  uint32_t Address = EEPROM_START_ADDRESS, PageEndAddress = EEPROM_START_ADDRESS+PAGE_SIZE;
+
+  /* Get valid Page for write operation */
+  ValidPage = EE_FindValidPage(WRITE_IN_VALID_PAGE);
+  
+  /* Check if there is no valid page */
+  if (ValidPage == NO_VALID_PAGE)
+  {
+    return  NO_VALID_PAGE;
+  }
+
+  /* Get the valid Page start Address */
+  Address = (uint32_t)(EEPROM_START_ADDRESS + (uint32_t)(ValidPage * PAGE_SIZE));
+
+  /* Get the valid Page end Address */
+  PageEndAddress = (uint32_t)((EEPROM_START_ADDRESS - 1) + (uint32_t)((ValidPage + 1) * PAGE_SIZE));
+
+  /* Check each active page address starting from beginning */
+  while (Address < PageEndAddress)
+  {
+    /* Verify if Address and Address+2 contents are 0xFFFFFFFF */
+    if ((*(__IO uint32_t*)Address) == 0xFFFFFFFF)
+    {
+      /* Set variable data */
+      FlashStatus = HAL_FLASH_Program(TYPEPROGRAM_HALFWORD, Address, Data);       
+      /* If program operation was failed, a Flash error code is returned */
+      if (FlashStatus != HAL_OK)
+      {
+        return FlashStatus;
+      }
+      /* Set variable virtual address */
+      FlashStatus = HAL_FLASH_Program(TYPEPROGRAM_HALFWORD, Address + 2, VirtAddress);       
+      /* Return program operation status */
+      return FlashStatus;
+    }
+    else
+    {
+      /* Next address location */
+      Address = Address + 4;
+    }
+  }
+
+  /* Return PAGE_FULL in case the valid page is full */
+  return PAGE_FULL;
+}
+
+/**
+  * @brief  Transfers last updated variables data from the full Page to
+  *   an empty one.
+  * @param  VirtAddress: 16 bit virtual address of the variable
+  * @param  Data: 16 bit data to be written as variable value
+  * @retval Success or error status:
+  *           - FLASH_COMPLETE: on success
+  *           - PAGE_FULL: if valid page is full
+  *           - NO_VALID_PAGE: if no valid page was found
+  *           - Flash error code: on write Flash error
+  */
+static uint16_t EE_PageTransfer(uint16_t VirtAddress, uint16_t Data)
+{
+  HAL_StatusTypeDef FlashStatus = HAL_OK;
+  uint32_t NewPageAddress = EEPROM_START_ADDRESS;
+  uint16_t OldPageId=0;
+  uint16_t ValidPage = PAGE0, VarIdx = 0;
+  uint16_t EepromStatus = 0, ReadStatus = 0;
+  uint32_t SectorError = 0;
+  FLASH_EraseInitTypeDef pEraseInit;
+
+  /* Get active Page for read operation */
+  ValidPage = EE_FindValidPage(READ_FROM_VALID_PAGE);
+
+  if (ValidPage == PAGE1)       /* Page1 valid */
+  {
+    /* New page address where variable will be moved to */
+    NewPageAddress = PAGE0_BASE_ADDRESS;
+
+    /* Old page ID where variable will be taken from */
+    OldPageId = PAGE1_ID;
+  }
+  else if (ValidPage == PAGE0)  /* Page0 valid */
+  {
+    /* New page address  where variable will be moved to */
+    NewPageAddress = PAGE1_BASE_ADDRESS;
+
+    /* Old page ID where variable will be taken from */
+    OldPageId = PAGE0_ID;
+  }
+  else
+  {
+    return NO_VALID_PAGE;       /* No valid Page */
+  }
+
+  /* Set the new Page status to RECEIVE_DATA status */
+  FlashStatus = HAL_FLASH_Program(TYPEPROGRAM_HALFWORD, NewPageAddress, RECEIVE_DATA);  
+  /* If program operation was failed, a Flash error code is returned */
+  if (FlashStatus != HAL_OK)
+  {
+    return FlashStatus;
+  }
+  
+  /* Write the variable passed as parameter in the new active page */
+  EepromStatus = EE_VerifyPageFullWriteVariable(VirtAddress, Data);
+  /* If program operation was failed, a Flash error code is returned */
+  if (EepromStatus != HAL_OK)
+  {
+    return EepromStatus;
+  }
+
+  /* Transfer process: transfer variables from old to the new active page */
+  for (VarIdx = 0; VarIdx < NB_OF_VAR; VarIdx++)
+  {
+    if (VirtAddVarTab[VarIdx] != VirtAddress)  /* Check each variable except the one passed as parameter */
+    {
+      /* Read the other last variable updates */
+      ReadStatus = EE_ReadVariable(VirtAddVarTab[VarIdx], &DataVar);
+      /* In case variable corresponding to the virtual address was found */
+      if (ReadStatus != 0x1)
+      {
+        /* Transfer the variable to the new active page */
+        EepromStatus = EE_VerifyPageFullWriteVariable(VirtAddVarTab[VarIdx], DataVar);
+        /* If program operation was failed, a Flash error code is returned */
+        if (EepromStatus != HAL_OK)
+        {
+          return EepromStatus;
+        }
+      }
+    }
+  }
+
+  pEraseInit.TypeErase = TYPEERASE_SECTORS;
+  pEraseInit.Sector = OldPageId;
+  pEraseInit.NbSectors = 1;
+  pEraseInit.VoltageRange = VOLTAGE_RANGE;
+  
+  /* Erase the old Page: Set old Page status to ERASED status */
+  FlashStatus = HAL_FLASHEx_Erase(&pEraseInit, &SectorError);  
+  /* If erase operation was failed, a Flash error code is returned */
+  if (FlashStatus != HAL_OK)
+  {
+    return FlashStatus;
+  }
+
+  /* Set new Page status to VALID_PAGE status */
+  FlashStatus = HAL_FLASH_Program(TYPEPROGRAM_HALFWORD, NewPageAddress, VALID_PAGE);   
+  /* If program operation was failed, a Flash error code is returned */
+  if (FlashStatus != HAL_OK)
+  {
+    return FlashStatus;
+  }
+
+  /* Return last operation flash status */
+  return FlashStatus;
+}
+
+/**
+  * @}
+  */ 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -570,8 +570,8 @@ StartDefaultTask(void* argument)
   eeprom_data_init();
 
   totp_service service_loaded;
-  eeprom_store_key(&service1);
-  eeprom_read_key(&service_loaded);
+  eeprom_store_service(&service1);
+  eeprom_read_service(&service_loaded);
 
   util_display_init();
 
@@ -580,8 +580,6 @@ StartDefaultTask(void* argument)
   char hmac1_digest_formatted[SHA_DIGEST_SIZE * 2] = "";
   int totp_res = 0;
   int epoch_time = 0;
-
-  // util_usart_printf("KEY=%s", HMAC_DEFAULT_KEY);
 
   /* Update epoch time */
   epoch_time = 0;
@@ -595,9 +593,11 @@ StartDefaultTask(void* argument)
   strncpy(conf_raw, dqueue.buf, max(64, MSG_BUF_SIZE));
   printf("\nGot conf text: %s\n", conf_raw);
 
-  totp_service service;
   util_parse_conf(conf_raw, strlen(conf_raw));
-  // printf("[STM32F412ZG]\r\n");
+
+  for (int i = 0; i < service_count; i++) {
+    eeprom_store_service(&service_list[i]);
+  }
 
   while (1) {
     util_display_totp_multi(service_list, service_count);

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -163,52 +163,14 @@ main(void)
   /* --- Store successively many values of the three variables in the EEPROM
    * ---*/
   /* Store 0x1000 values of Variable1 in EEPROM */
-  for (VarValue = 1; VarValue <= 0x1000; VarValue++) {
-    /* Sequence 1 */
-    if ((EE_WriteVariable(VirtAddVarTab[0], VarValue)) != HAL_OK) {
-      Error_Handler();
-    }
-    if ((EE_ReadVariable(VirtAddVarTab[0], &VarDataTab[0])) != HAL_OK) {
-      Error_Handler();
-    }
-    if (VarValue != VarDataTab[0]) {
-      Error_Handler();
-    }
-
-    /* Sequence 2 */
-    if (EE_WriteVariable(VirtAddVarTab[1], ~VarValue) != HAL_OK) {
-      Error_Handler();
-    }
-    if (EE_ReadVariable(VirtAddVarTab[1], &VarDataTab[1]) != HAL_OK) {
-      Error_Handler();
-    }
-    if (((uint16_t)~VarValue) != VarDataTab[1]) {
-      Error_Handler();
-    }
-
-    /* Sequence 3 */
-    if (EE_WriteVariable(VirtAddVarTab[2], VarValue << 1) != HAL_OK) {
-      Error_Handler();
-    }
-    if (EE_ReadVariable(VirtAddVarTab[2], &VarDataTab[2]) != HAL_OK) {
-      Error_Handler();
-    }
-    if ((VarValue << 1) != VarDataTab[2]) {
-      Error_Handler();
-    }
+  if ((EE_WriteVariable(VirtAddVarTab[0], VarValue)) != HAL_OK) {
+    Error_Handler();
   }
-
-  /* Store 0x2000 values of Variable2 in EEPROM */
-  for (VarValue = 1; VarValue <= 0x2000; VarValue++) {
-    if (EE_WriteVariable(VirtAddVarTab[1], VarValue) != HAL_OK) {
-      Error_Handler();
-    }
-    if (EE_ReadVariable(VirtAddVarTab[1], &VarDataTab[1]) != HAL_OK) {
-      Error_Handler();
-    }
-    if (VarValue != VarDataTab[1]) {
-      Error_Handler();
-    }
+  if ((EE_ReadVariable(VirtAddVarTab[0], &VarDataTab[0])) != HAL_OK) {
+    Error_Handler();
+  }
+  if (VarValue != VarDataTab[0]) {
+    Error_Handler();
   }
 
   /* read the last stored variables data*/
@@ -218,58 +180,8 @@ main(void)
   if (VarDataTmp != VarDataTab[0]) {
     Error_Handler();
   }
+  HAL_FLASH_Lock();
 
-  if (EE_ReadVariable(VirtAddVarTab[1], &VarDataTmp) != HAL_OK) {
-    Error_Handler();
-  }
-  if (VarDataTmp != VarDataTab[1]) {
-    Error_Handler();
-  }
-
-  if (EE_ReadVariable(VirtAddVarTab[2], &VarDataTmp) != HAL_OK) {
-    Error_Handler();
-  }
-  if (VarDataTmp != VarDataTab[2]) {
-    Error_Handler();
-  }
-
-  /* Store 0x3000 values of Variable3 in EEPROM */
-  for (VarValue = 1; VarValue <= 0x3000; VarValue++) {
-    if (EE_WriteVariable(VirtAddVarTab[2], VarValue) != HAL_OK) {
-      Error_Handler();
-    }
-    if (EE_ReadVariable(VirtAddVarTab[2], &VarDataTab[2]) != HAL_OK) {
-      Error_Handler();
-    }
-    if (VarValue != VarDataTab[2]) {
-      Error_Handler();
-    }
-  }
-
-  /* read the last stored variables data*/
-  if (EE_ReadVariable(VirtAddVarTab[0], &VarDataTmp) != HAL_OK) {
-    Error_Handler();
-  }
-  if (VarDataTmp != VarDataTab[0]) {
-    Error_Handler();
-  }
-
-  if (EE_ReadVariable(VirtAddVarTab[1], &VarDataTmp) != HAL_OK) {
-    Error_Handler();
-  }
-  if (VarDataTmp != VarDataTab[1]) {
-    Error_Handler();
-  }
-
-  if (EE_ReadVariable(VirtAddVarTab[2], &VarDataTmp) != HAL_OK) {
-    Error_Handler();
-  }
-  if (VarDataTmp != VarDataTab[2]) {
-    Error_Handler();
-  }
-
-  for (;;)
-    ;
   /* USER CODE END 2 */
 
   /* Init scheduler */

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -79,9 +79,8 @@ extern totp_service service_list[];
 extern int service_count;
 extern long epoch_global;
 
-uint16_t VirtAddVarTab[NB_OF_VAR] = { 0x5555, 0x6666, 0x7777 };
-uint16_t VarDataTab[NB_OF_VAR] = { 0, 0, 0 };
-uint16_t VarValue, VarDataTmp = 0;
+const totp_service service1 = { "abcdefgh", "12345678" };
+
 /* USER CODE END PV */
 
 /* Private function prototypes -----------------------------------------------*/
@@ -153,34 +152,6 @@ main(void)
   /* USER CODE BEGIN 2 */
   // util_usart_printstr("[STM32F412ZG]Starting...\r\n");
   printf("[STM32F412ZG]Starting...\r\n");
-
-  HAL_FLASH_Unlock();
-  /* EEPROM Init */
-  if (EE_Init() != EE_OK) {
-    Error_Handler();
-  }
-
-  /* --- Store successively many values of the three variables in the EEPROM
-   * ---*/
-  /* Store 0x1000 values of Variable1 in EEPROM */
-  if ((EE_WriteVariable(VirtAddVarTab[0], VarValue)) != HAL_OK) {
-    Error_Handler();
-  }
-  if ((EE_ReadVariable(VirtAddVarTab[0], &VarDataTab[0])) != HAL_OK) {
-    Error_Handler();
-  }
-  if (VarValue != VarDataTab[0]) {
-    Error_Handler();
-  }
-
-  /* read the last stored variables data*/
-  if (EE_ReadVariable(VirtAddVarTab[0], &VarDataTmp) != HAL_OK) {
-    Error_Handler();
-  }
-  if (VarDataTmp != VarDataTab[0]) {
-    Error_Handler();
-  }
-  HAL_FLASH_Lock();
 
   /* USER CODE END 2 */
 
@@ -596,6 +567,12 @@ void
 StartDefaultTask(void* argument)
 {
   /* USER CODE BEGIN 5 */
+  eeprom_data_init();
+
+  totp_service service_loaded;
+  eeprom_store_key(&service1);
+  eeprom_read_key(&service_loaded);
+
   util_display_init();
 
   byte hmac256_digest[SHA256_DIGEST_SIZE] = "";

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -630,7 +630,7 @@ StartCommsTask(void* argument)
     util_usart_readline(uart_line_buffer);
   }
   util_usart_printf("\n%s\n", uart_line_buffer);
-  strcpy(dqueue.buf, uart_line_buffer + strlen(conf_start));
+  strcpy(dqueue.buf, uart_line_buffer);
   osMessageQueuePut(commsQueueHandle, dqueue.buf, NULL, osWaitForever);
 
   // rtc_demo();

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -78,6 +78,10 @@ extern char uart_line_buffer[];
 extern totp_service service_list[];
 extern int service_count;
 extern long epoch_global;
+
+uint16_t VirtAddVarTab[NB_OF_VAR] = { 0x5555, 0x6666, 0x7777 };
+uint16_t VarDataTab[NB_OF_VAR] = { 0, 0, 0 };
+uint16_t VarValue, VarDataTmp = 0;
 /* USER CODE END PV */
 
 /* Private function prototypes -----------------------------------------------*/
@@ -103,7 +107,6 @@ void
 StartCommsTask(void* argument);
 
 /* USER CODE BEGIN PFP */
-
 /* USER CODE END PFP */
 
 /* Private user code ---------------------------------------------------------*/
@@ -150,6 +153,123 @@ main(void)
   /* USER CODE BEGIN 2 */
   // util_usart_printstr("[STM32F412ZG]Starting...\r\n");
   printf("[STM32F412ZG]Starting...\r\n");
+
+  HAL_FLASH_Unlock();
+  /* EEPROM Init */
+  if (EE_Init() != EE_OK) {
+    Error_Handler();
+  }
+
+  /* --- Store successively many values of the three variables in the EEPROM
+   * ---*/
+  /* Store 0x1000 values of Variable1 in EEPROM */
+  for (VarValue = 1; VarValue <= 0x1000; VarValue++) {
+    /* Sequence 1 */
+    if ((EE_WriteVariable(VirtAddVarTab[0], VarValue)) != HAL_OK) {
+      Error_Handler();
+    }
+    if ((EE_ReadVariable(VirtAddVarTab[0], &VarDataTab[0])) != HAL_OK) {
+      Error_Handler();
+    }
+    if (VarValue != VarDataTab[0]) {
+      Error_Handler();
+    }
+
+    /* Sequence 2 */
+    if (EE_WriteVariable(VirtAddVarTab[1], ~VarValue) != HAL_OK) {
+      Error_Handler();
+    }
+    if (EE_ReadVariable(VirtAddVarTab[1], &VarDataTab[1]) != HAL_OK) {
+      Error_Handler();
+    }
+    if (((uint16_t)~VarValue) != VarDataTab[1]) {
+      Error_Handler();
+    }
+
+    /* Sequence 3 */
+    if (EE_WriteVariable(VirtAddVarTab[2], VarValue << 1) != HAL_OK) {
+      Error_Handler();
+    }
+    if (EE_ReadVariable(VirtAddVarTab[2], &VarDataTab[2]) != HAL_OK) {
+      Error_Handler();
+    }
+    if ((VarValue << 1) != VarDataTab[2]) {
+      Error_Handler();
+    }
+  }
+
+  /* Store 0x2000 values of Variable2 in EEPROM */
+  for (VarValue = 1; VarValue <= 0x2000; VarValue++) {
+    if (EE_WriteVariable(VirtAddVarTab[1], VarValue) != HAL_OK) {
+      Error_Handler();
+    }
+    if (EE_ReadVariable(VirtAddVarTab[1], &VarDataTab[1]) != HAL_OK) {
+      Error_Handler();
+    }
+    if (VarValue != VarDataTab[1]) {
+      Error_Handler();
+    }
+  }
+
+  /* read the last stored variables data*/
+  if (EE_ReadVariable(VirtAddVarTab[0], &VarDataTmp) != HAL_OK) {
+    Error_Handler();
+  }
+  if (VarDataTmp != VarDataTab[0]) {
+    Error_Handler();
+  }
+
+  if (EE_ReadVariable(VirtAddVarTab[1], &VarDataTmp) != HAL_OK) {
+    Error_Handler();
+  }
+  if (VarDataTmp != VarDataTab[1]) {
+    Error_Handler();
+  }
+
+  if (EE_ReadVariable(VirtAddVarTab[2], &VarDataTmp) != HAL_OK) {
+    Error_Handler();
+  }
+  if (VarDataTmp != VarDataTab[2]) {
+    Error_Handler();
+  }
+
+  /* Store 0x3000 values of Variable3 in EEPROM */
+  for (VarValue = 1; VarValue <= 0x3000; VarValue++) {
+    if (EE_WriteVariable(VirtAddVarTab[2], VarValue) != HAL_OK) {
+      Error_Handler();
+    }
+    if (EE_ReadVariable(VirtAddVarTab[2], &VarDataTab[2]) != HAL_OK) {
+      Error_Handler();
+    }
+    if (VarValue != VarDataTab[2]) {
+      Error_Handler();
+    }
+  }
+
+  /* read the last stored variables data*/
+  if (EE_ReadVariable(VirtAddVarTab[0], &VarDataTmp) != HAL_OK) {
+    Error_Handler();
+  }
+  if (VarDataTmp != VarDataTab[0]) {
+    Error_Handler();
+  }
+
+  if (EE_ReadVariable(VirtAddVarTab[1], &VarDataTmp) != HAL_OK) {
+    Error_Handler();
+  }
+  if (VarDataTmp != VarDataTab[1]) {
+    Error_Handler();
+  }
+
+  if (EE_ReadVariable(VirtAddVarTab[2], &VarDataTmp) != HAL_OK) {
+    Error_Handler();
+  }
+  if (VarDataTmp != VarDataTab[2]) {
+    Error_Handler();
+  }
+
+  for (;;)
+    ;
   /* USER CODE END 2 */
 
   /* Init scheduler */
@@ -665,6 +785,7 @@ Error_Handler(void)
   /* USER CODE BEGIN Error_Handler_Debug */
   /* User can add his own implementation to report the HAL error return state
    */
+  printf("Error! ");
   __disable_irq();
   while (1) {
   }

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ Core/Src/user_utils.c \
 Core/Src/crypt.c \
 Core/Src/time_rtc.c \
 Core/Src/circular_buffer.c \
+Core/Src/eeprom.c \
 Core/Src/stm32f4xx_it.c \
 Core/Src/stm32f4xx_hal_msp.c \
 Core/Src/stm32f4xx_hal_timebase_tim.c \

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ Core/Src/crypt.c \
 Core/Src/time_rtc.c \
 Core/Src/circular_buffer.c \
 Core/Src/eeprom.c \
+Core/Src/data_persist.c \
 Core/Src/stm32f4xx_it.c \
 Core/Src/stm32f4xx_hal_msp.c \
 Core/Src/stm32f4xx_hal_timebase_tim.c \

--- a/README.md
+++ b/README.md
@@ -91,3 +91,6 @@ Bin version:2.4.0(MINI-1)
 
 OK
 ```
+
+
+https://www.eevblog.com/forum/microcontrollers/eeprom-emulation-stm32f4-flash-vs-external-flash-chip/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ A hardware [TOTP](https://en.wikipedia.org/wiki/Time-based_one-time_password) to
 
 ---
 - [TOTP Token](#totp-token)
+  - [Features](#features)
   - [Getting Started](#getting-started)
     - [Software Requirements](#software-requirements)
       - [MacOS with `HomeBrew`](#macos-with-homebrew)
@@ -15,6 +16,15 @@ A hardware [TOTP](https://en.wikipedia.org/wiki/Time-based_one-time_password) to
       - [Hardware Connection](#hardware-connection)
       - [Samples](#samples)
 ---
+## Features
+- [x] Data download over UART
+  - [x] Serial data parsing
+- [x] Data persistence with EEPROM Emulation
+- [x] [Web app for TOTP service data management](https://github.com/mistrpokr/tinytotp-web)
+- [ ] Epoch time tracking with RTC on battery
+- [ ] PCB Design
+
+
 ## Getting Started
 This project is primarily set up with STM32CubeMX and can be with `gcc` and `make`. 
 

--- a/STM32F412ZGTx_FLASH.ld
+++ b/STM32F412ZGTx_FLASH.ld
@@ -59,10 +59,13 @@ _Min_Heap_Size = 0x200;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */
 
 /* Specify the memory areas */
+/* Reference: https://electronics.stackexchange.com/questions/391645/stm32f4-adjust-linker-script-to-save-memory-for-eeprom-emulation */
 MEMORY
 {
 RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 256K
-FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 1024K
+FLASH_BOOT (rx)      : ORIGIN = 0x8000000, LENGTH = 32K
+EMULATED_EEPROM (xrw) : ORIGIN = 0x8008000, LENGTH = 32K
+FLASH (rx)  : ORIGIN = 0x8010000, LENGTH = 960K
 }
 
 /* Define output sections */
@@ -74,7 +77,7 @@ SECTIONS
     . = ALIGN(4);
     KEEP(*(.isr_vector)) /* Startup code */
     . = ALIGN(4);
-  } >FLASH
+  } >FLASH_BOOT
 
   /* The program code and other data goes into FLASH */
   .text :


### PR DESCRIPTION
Flash page 2 and 3 are used to emulate EEPROM and store service name and secrets from user. See this [application note](https://www.st.com/resource/en/application_note/dm00036065.pdf) for STM32F4 series. Requires modification of linker script so that instruction data are not stored in modifiable areas of flash. 

At boot, a "index" variable is checked to return a number of service data stored into EEPROM last time. These data are read and parsed, and are finally displayed to the LCD. If there are not any data stored, it prompts for a data download from the UART, which can be done with the web application with WebSerial. 

Note that some STM32 variants (e.g L series) are shipped with internal EEPROM, but at least not on F412. 